### PR TITLE
V1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The easy to use library for your data, configuration, and save files
 
 [![Functionality-QA-Tests](https://github.com/aaronater10/sfcparse/actions/workflows/sfcparse_functionality_testing.yml/badge.svg)](https://github.com/aaronater10/sfcparse/actions/workflows/sfcparse_functionality_testing.yml)
 
-##### Latest Version: 1.1.1
+##### Latest Version: 1.1.2
 
 #
 

--- a/src/sfcparse/__init__.py
+++ b/src/sfcparse/__init__.py
@@ -2,7 +2,7 @@
 Simple File Configuration Parse - by aaronater10
 More info: https://github.com/aaronater10/sfcparse
 
-Version 1.1.1
+Version 1.1.2
 
 The easy to use library for data and configuration files.
 

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -14,7 +14,7 @@ class _Importfile:
 # Import py Data from File
 class __importfile:
     class file_data:
-        def __init__(self, filename: str):
+        def __init__(self, filename: str, attrib_name_dedup: bool):
 
             # Validate file exists. Open and Import Config File into Class Object then return the object    
             try:
@@ -24,6 +24,7 @@ class __importfile:
 
             # Syntax Error Message
             __py_syntax_err_msg = "Must have valid Python data types to import, or file is not formatted correctly"
+            __name_preexists_err_msg = "Name already preexists. Must give unique attribute names in file"
             
             # Data Build Setup and Switches        
             __is_building_data_sw = False
@@ -68,6 +69,10 @@ class __importfile:
                     
                     # START BUILD: Check if value in file line is only Start Marker. Check if Multiline or Single Line
                     if (__value_token_multi in __start_markers) and ((__last_token in __start_markers) or (__start_skip_token[0] in __skip_markers)) and (__is_building_data_sw == False):
+                        
+                        if (attrib_name_dedup) and (__var_token in vars(self).keys()):
+                                raise _Importfile.importfile(__name_preexists_err_msg, f'\nFILE: "{filename}" \nATTRIB_NAME: {__var_token}')
+
                         __build_data = __value_token
                         
                         # Turn ON Data Build Switches
@@ -96,13 +101,18 @@ class __importfile:
                         
                     # IMPORT SINLGE LINE VALUES: If not multiline, assume single
                     else:
-                        try: setattr(self, __var_token, __literal_eval__(__value_token))
+                        try: 
+                            if (attrib_name_dedup) and (__var_token in vars(self).keys()):
+                                raise _Importfile.importfile(__name_preexists_err_msg, f'\nFILE: "{filename}" \nATTRIB_NAME: {__var_token}')
+                            
+                            setattr(self, __var_token, __literal_eval__(__value_token))
+                            
                         except ValueError: raise _Importfile.importfile(__py_syntax_err_msg, f'"{filename}"')
                 
                 else: raise _Importfile.importfile(__py_syntax_err_msg, f'"{filename}"')
 
 
-def importfile(filename: str) -> '__importfile.file_data':
+def importfile(filename: str, attrib_name_dedup: bool=True) -> '__importfile.file_data':
     """
     Imports saved python data from any text file.
 
@@ -117,10 +127,12 @@ def importfile(filename: str) -> '__importfile.file_data':
     [Example Use]
     importfile('filename.data' or 'path/to/filename.data')
     """
-    __err_msg = f'Invalid data type or nothing specified: "{filename}"'
-    # Check if filename is str
-    if not isinstance(filename, str):
-        raise _Importfile.importfile(__err_msg, f'"{filename}"')
+    __err_msg_file = 'Invalid data type or nothing specified for filename:'
+    __err_msg_attrib = 'Invalid data type or nothing specified for attrib_name_dedup:'
+    
+    # Error Checks
+    if not isinstance(filename, str): raise _Importfile.importfile(__err_msg_file, f'"{filename}"')
+    if not isinstance(attrib_name_dedup, bool): raise _Importfile.importfile(__err_msg_attrib, f'"{attrib_name_dedup}"')
 
     # Check if file empty. Returns None if empty
     try:
@@ -129,4 +141,4 @@ def importfile(filename: str) -> '__importfile.file_data':
     except FileNotFoundError as __err_msg: raise _Importfile.importfile(__err_msg, f'"{filename}"')
 
     # Return Final Import
-    return __importfile.file_data(filename)
+    return __importfile.file_data(filename, attrib_name_dedup)

--- a/tests/native/test_importfile.py
+++ b/tests/native/test_importfile.py
@@ -201,3 +201,27 @@ def test10_misc_data_import():
     assert (file_import.data_set == {1,2,3}) and (isinstance(file_import.data_set, set))
     assert (file_import.data_token1 == ['normal value', "var = 'value'", 'normal value']) and (isinstance(file_import.data_token1, list))
     assert (file_import.data_end_token1 == ['normal value', "var = 'value'", 'normal value']) and (isinstance(file_import.data_end_token1, list))
+
+
+# 11. Single-Line Attr Dedup OFF - Turning OFF Attribute Dedup Feature Test
+def test11_single_attr_dedup_off():
+    filename = '11_attr_dedup_off_single.data'
+    filepath = test_file_path + filename
+
+    # Test Turn OFF Attr Dedup Protection
+    file_import = sfcparse.importfile(filepath, False)
+
+    # Test Attributes and Types - Confirm data and it's type was in fact changed inside file
+    assert (file_import.data_dict == "changed data") and (isinstance(file_import.data_dict, str))
+
+
+# 12. Multi-Line Attr Dedup OFF - Turning OFF Attribute Dedup Feature Test
+def test12_multi_attr_dedup_off():
+    filename = '12_attr_dedup_off_multi.data'
+    filepath = test_file_path + filename
+
+    # Test Turn OFF Attr Dedup Protection
+    file_import = sfcparse.importfile(filepath, False)
+
+    # Test Attributes and Types - Confirm data and it's type was in fact changed inside file
+    assert (file_import.data_list == "changed data") and (isinstance(file_import.data_list, str))

--- a/tests/native/test_sec_importfile.py
+++ b/tests/native/test_sec_importfile.py
@@ -18,11 +18,31 @@ class Test1CodeNotExec(unittest.TestCase):
             sfcparse.importfile(filepath)
 
 
-# 2. Code on Line Import - Importing Config File with a Line in File that has Executable Code
+# 2. Code on Line Import - Importing Config File with a Line in File that contains Executable Code
 class Test2CodeNotExec(unittest.TestCase):
 
     def test2_code_notexec_import(self):
         filename = '2_code_notexec.data'
+        filepath = test_file_path + filename
+        with self.assertRaises(Exception):
+            sfcparse.importfile(filepath)
+
+
+# 3. Single-Line Attribute Protect - Halting Import of Config File with Duplicate Attributes
+class Test3SingleAttrProtect(unittest.TestCase):
+
+    def test3_single_attr_protect(self):
+        filename = '3_singleline_attr_protect.data'
+        filepath = test_file_path + filename
+        with self.assertRaises(Exception):
+            sfcparse.importfile(filepath)
+
+
+# 4. Multi-Line Attribute Protect - Halting Import of Config File with Duplicate Attributes
+class Test4MultiAttrProtect(unittest.TestCase):
+
+    def test4_multi_attr_protect(self):
+        filename = '4_multiline_attr_protect.data'
         filepath = test_file_path + filename
         with self.assertRaises(Exception):
             sfcparse.importfile(filepath)

--- a/tests/test_files/native/importfile_files/11_attr_dedup_off_single.data
+++ b/tests/test_files/native/importfile_files/11_attr_dedup_off_single.data
@@ -1,0 +1,13 @@
+data_str = "data"
+data_int = 1
+data_float = 1.0
+data_bool = True
+data_list = [1,2,3]
+data_dict = {'k1':1, 'k2':2, 'k3':3}
+data_tuple = (1,2,3)
+data_set = {1,2,3}
+data_none = None
+data_bytes = b'data'
+
+# Value already pre-declared
+data_dict = 'changed data'

--- a/tests/test_files/native/importfile_files/12_attr_dedup_off_multi.data
+++ b/tests/test_files/native/importfile_files/12_attr_dedup_off_multi.data
@@ -1,0 +1,23 @@
+data_list = [
+    1,
+    2,
+    3
+]
+data_dict = {
+    'k1': 1,
+    'k2': 2,
+    'k3': 3
+}
+data_tuple = (
+    1,
+    2,
+    3
+)
+data_set = {
+    1,
+    2,
+    3
+}
+
+# Value already pre-declared
+data_list = 'changed data'

--- a/tests/test_files/native/sec_importfile_files/3_singleline_attr_protect.data
+++ b/tests/test_files/native/sec_importfile_files/3_singleline_attr_protect.data
@@ -1,0 +1,13 @@
+data_str = "data"
+data_int = 1
+data_float = 1.0
+data_bool = True
+data_list = [1,2,3]
+data_dict = {'k1':1, 'k2':2, 'k3':3}
+data_tuple = (1,2,3)
+data_set = {1,2,3}
+data_none = None
+data_bytes = b'data'
+
+# Value already pre-declared
+data_dict = 'changed data'

--- a/tests/test_files/native/sec_importfile_files/4_multiline_attr_protect.data
+++ b/tests/test_files/native/sec_importfile_files/4_multiline_attr_protect.data
@@ -1,0 +1,23 @@
+data_list = [
+    1,
+    2,
+    3
+]
+data_dict = {
+    'k1': 1,
+    'k2': 2,
+    'k3': 3
+}
+data_tuple = (
+    1,
+    2,
+    3
+)
+data_set = {
+    1,
+    2,
+    3
+}
+
+# Value already pre-declared
+data_list = 'changed data'


### PR DESCRIPTION
added new attr dedup protection when using importfile. This was considered a bug and potential security issue when data being imported could have already been pre-declared and you were not notified, or a malicious attempt to change an attribute's data to be overwritten