### PR TITLE
v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The easy to use library for your data, configuration, and save files
 
 [![Functionality-QA-Tests](https://github.com/aaronater10/sfcparse/actions/workflows/sfcparse_functionality_testing.yml/badge.svg)](https://github.com/aaronater10/sfcparse/actions/workflows/sfcparse_functionality_testing.yml)
 
-##### Latest Version: 1.2.1
+##### Latest Version: 1.3.0
 
 #
 

--- a/deploy/pypi_sfcparse_build_deploy.py
+++ b/deploy/pypi_sfcparse_build_deploy.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 
 # Setup
-SFCPARSE_VERSION = "1.2.1"
+SFCPARSE_VERSION = "1.3.0"
 DEPLOY_API_TOKEN = f"{sys.argv[1]}"
 USER_HOMEPATH = os.getenv('HOME')
 USER_PYPI_CFG_FILE = f"{USER_HOMEPATH}/.pypirc"

--- a/src/sfcparse/__init__.py
+++ b/src/sfcparse/__init__.py
@@ -1,7 +1,7 @@
 """
 Simple File Configuration Parse - by aaronater10
 
-Version 1.2.1
+Version 1.3.0
 
 The easy to use library for your data, configuration, and save files.
 

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -106,7 +106,7 @@ class FileData:
                         if __current_assignment_operator == __assignment_operator_markers[1]:
                             self.__assignment_locked_attribs.append(__var_token)
 
-                    except SyntaxError: raise ImportFile(__py_syntax_err_msg, f'\nFILE: "{filename}"')
+                    except SyntaxError: raise ImportFile(__py_syntax_err_msg, f'\nFILE: "{filename}" \nATTRIB_NAME: {__var_token}')
 
                     # Turn OFF Data Build Switches
                     __is_building_data_sw = False
@@ -143,15 +143,15 @@ class FileData:
                         if __current_assignment_operator == __assignment_operator_markers[1]:
                             self.__assignment_locked_attribs.append(__var_token)
                         
-                    except ValueError: raise ImportFile(__py_syntax_err_msg, f'\nFILE: "{filename}"')
+                    except ValueError: raise ImportFile(__py_syntax_err_msg, f'\nFILE: "{filename}" \nATTRIB_NAME: {__var_token}')
                     except AttributeError:
-                        
                         # REF_NAME: Ignores Comments to Display Attr Reference Name
                         raise ImportFile(
                             __name_reference_does_not_exist,
                             f'\nFILE: "{filename}" \nATTRIB_NAME: {__var_token} \nREF_NAME: {f"{__value_token} "[:__value_token.find(__skip_markers[2])].rstrip()}'
                         )
-            
+                    except SyntaxError: raise ImportFile(__py_syntax_err_msg, f'\nFILE: "{filename}" \nATTRIB_NAME: {__var_token}')
+
             else: raise ImportFile(__py_syntax_err_msg, f'\nFILE: "{filename}"')
     
 

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -36,7 +36,7 @@ class FileData:
         __start_markers = ('[','{','(')
         __end_markers = (']','}',')')
         __skip_markers = ('',' ','#','\n')
-        __assignment_operator_markers = ('=', '$=')
+        __assignment_operator_markers = ('=', '$=', '==')
         __eof_marker = f[-1]
 
         # Main File Loop
@@ -116,6 +116,11 @@ class FileData:
                         if (self.__attrib_name_dedup) and (hasattr(self, __var_token)):
                             raise ImportFile(__name_preexists_err_msg, f'\nFILE: "{filename}" \nATTRIB_NAME: {__var_token}')
                         
+                        # Check if Attr is a Reference to Another Attr for Assignment
+                        if __current_assignment_operator == __assignment_operator_markers[2]:
+                            setattr(self, __var_token, getattr(self, __value_token))
+                            continue
+
                         # Assign Attr
                         setattr(self, __var_token, __literal_eval__(__value_token))
 

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -36,7 +36,7 @@ class FileData:
         __start_markers = ('[','{','(')
         __end_markers = (']','}',')')
         __skip_markers = ('',' ','#','\n')
-        __assignment_operator_markers = ('=', '$=', '==')
+        __assignment_operator_markers = ('=', '$=', '==', '$==')
         __eof_marker = f[-1]
 
         # Main File Loop
@@ -116,9 +116,14 @@ class FileData:
                         if (self.__attrib_name_dedup) and (hasattr(self, __var_token)):
                             raise ImportFile(__name_preexists_err_msg, f'\nFILE: "{filename}" \nATTRIB_NAME: {__var_token}')
                         
-                        # Check if Attr is a Reference to Another Attr for Assignment
+                        # Check if Attr is a Reference to Another Attr's Value for Assignment
                         if __current_assignment_operator == __assignment_operator_markers[2]:
                             setattr(self, __var_token, getattr(self, __value_token))
+                            continue
+                        # Check if Attr is a Reference to Another Attr's Value for Assignment and Locked from Re-Assignment
+                        if __current_assignment_operator == __assignment_operator_markers[3]:
+                            setattr(self, __var_token, getattr(self, __value_token))
+                            self.__assignment_locked_attribs.append(__var_token)
                             continue
 
                         # Assign Attr

--- a/tests/native/test_importfile.py
+++ b/tests/native/test_importfile.py
@@ -295,5 +295,12 @@ class TestImportFile(unittest.TestCase):
 
         with self.assertRaises(Exception): file_import.data_set = change_value
         self.assertEqual(file_import.data_set, {1,2,3})
+    
+    # 15. Mixed Attr/Regular Imports - Confirm Importing Attribute Locked and Regular Values in One File
+    def test15_attr_lock_mixed_imports(self):
+        filename = '15_attr_lock_mixed_imports.data'
+        filepath = test_file_path + filename
 
-        
+        # Test File Import
+        sfcparse.importfile(filepath)
+       

--- a/tests/native/test_importfile.py
+++ b/tests/native/test_importfile.py
@@ -19,7 +19,6 @@ class TestImportFile(unittest.TestCase):
         assert path.getsize(filepath) == 0, f"File Not Empty: {filename}"
         assert (sfcparse.importfile(filepath)) == None, f"Not None {filename}"
 
-
     # 2. Single Line Import - Importing Singles Lines of All Accepted Data Types
     def test2_single_line_import(self):
         filename = '2_single_line.data'
@@ -41,7 +40,6 @@ class TestImportFile(unittest.TestCase):
         assert (file_import.data_none == None) and (isinstance(file_import.data_none, type(None)))
         assert (file_import.data_bytes == b'data') and (isinstance(file_import.data_bytes, bytes))
 
-
     # 3. Multi Line Import - Importing Multi Line of All Accepted Data Types
     def test3_multi_line_import(self):
         filename = '3_multi_line.data'
@@ -56,7 +54,6 @@ class TestImportFile(unittest.TestCase):
         assert (file_import.data_dict == {'k1':1, 'k2':2, 'k3':3}) and (isinstance(file_import.data_dict, dict))
         assert (file_import.data_tuple == (1,2,3)) and (isinstance(file_import.data_tuple, tuple))
         assert (file_import.data_set == {1,2,3}) and (isinstance(file_import.data_set, set))
-
 
     # 4. Multi-Single Line Import - Importing Multi and Single Lines Together
     def test4_multi_single_line_import(self):
@@ -76,7 +73,6 @@ class TestImportFile(unittest.TestCase):
         assert (file_import.data_bytes == b'data') and (isinstance(file_import.data_bytes, bytes))
         assert (file_import.data_set == {1,2,3}) and (isinstance(file_import.data_set, set))
 
-
     # 5. Multi-Single Comments Import - Importing Multi and Single Lines with Comments
     def test5_multi_single_comments_import(self):
         filename = '5_multi-single_comments.data'
@@ -94,7 +90,6 @@ class TestImportFile(unittest.TestCase):
         assert (file_import.data_none == None) and (isinstance(file_import.data_none, type(None)))
         assert (file_import.data_bytes == b'data') and (isinstance(file_import.data_bytes, bytes))
         assert (file_import.data_set == {1,2,3}) and (isinstance(file_import.data_set, set))
-
 
     # 6. Nested Data Import - Importing Nested Data
     def test6_nested_data_import(self):
@@ -114,7 +109,6 @@ class TestImportFile(unittest.TestCase):
         assert (file_import.data_list[4] == {1, 2, 3}) and (isinstance(file_import.data_list[4], set))
         assert (file_import.data_list[5] == [1, 2, 3]) and (isinstance(file_import.data_list[5], list))
 
-
     # 7. White Space Import - Importing Data with White Space in Between
     def test7_white_space_import(self):
         filename = '7_white_space.data'
@@ -133,7 +127,6 @@ class TestImportFile(unittest.TestCase):
         assert (file_import.data_float == 1.0) and (isinstance(file_import.data_float, float))
         assert (file_import.data_set == {1,2,3}) and (isinstance(file_import.data_set, set))
         assert (file_import.data_bool == True) and (isinstance(file_import.data_bool, bool))
-
 
     # 8. All Multi-Single Line Types Import - Importing All Multi-Single Line Types Together
     def test8_all_multi_single_types_import(self):
@@ -163,7 +156,6 @@ class TestImportFile(unittest.TestCase):
         assert (file_import.data_none == None) and (isinstance(file_import.data_none, type(None)))
         assert (file_import.data_bytes == b'data') and (isinstance(file_import.data_bytes, bytes))
 
-
     # 9. Big Data Import - Importing 100K+ Values of Data with Single Lines
     def test9_big_data_import(self):
         filename = '9_big_data_with_singles.data'
@@ -181,7 +173,6 @@ class TestImportFile(unittest.TestCase):
         assert (len(file_import.data_multi) == big_data_len) and (isinstance(file_import.data_multi, dict))
         assert (file_import.data_none == None) and (isinstance(file_import.data_none, type(None)))
         assert (file_import.data_bytes == b'data') and (isinstance(file_import.data_bytes, bytes))
-
 
     # 10. Misc Behavior Import - Importing Misc, Odd, or Unique Data Inputs
     def test10_misc_data_import(self):
@@ -206,7 +197,6 @@ class TestImportFile(unittest.TestCase):
         assert (file_import.data_token1 == ['normal value', "var = 'value'", 'normal value']) and (isinstance(file_import.data_token1, list))
         assert (file_import.data_end_token1 == ['normal value', "var = 'value'", 'normal value']) and (isinstance(file_import.data_end_token1, list))
 
-
     # 11. Single-Line Attr Dedup OFF - Turning OFF Attribute Dedup Feature Test
     def test11_single_attr_dedup_off(self):
         filename = '11_attr_dedup_off_single.data'
@@ -218,7 +208,6 @@ class TestImportFile(unittest.TestCase):
         # Test Attributes and Types - Confirm data and it's type was in fact changed inside file
         assert (file_import.data_dict == "changed data") and (isinstance(file_import.data_dict, str))
 
-
     # 12. Multi-Line Attr Dedup OFF - Turning OFF Attribute Dedup Feature Test
     def test12_multi_attr_dedup_off(self):
         filename = '12_attr_dedup_off_multi.data'
@@ -229,7 +218,6 @@ class TestImportFile(unittest.TestCase):
 
         # Test Attributes and Types - Confirm data and it's type was in fact changed inside file
         assert (file_import.data_list == "changed data") and (isinstance(file_import.data_list, str))
-
 
     # 13. Single-Line Attr Lock - Attribute Locked and Cannot Re-Assign
     def test13_single_attr_lock(self):
@@ -272,7 +260,6 @@ class TestImportFile(unittest.TestCase):
         with self.assertRaises(Exception): file_import.data_bytes = change_value
         self.assertEqual(file_import.data_bytes, b'data')
 
-
     # 14. Single-Line Attr Lock - Attribute Locked and Cannot Re-Assign
     def test14_multi_attr_lock(self):
         filename = '14_attr_lock_multi.data'
@@ -302,5 +289,41 @@ class TestImportFile(unittest.TestCase):
         filepath = test_file_path + filename
 
         # Test File Import
-        sfcparse.importfile(filepath)
-       
+        sfcparse.importfile(filepath)    
+
+    # 16. Attr Referencing - Reference Pre-Defined Attr's Value and Confirm Assigned
+    def test16_attr_ref_single_multi(self):
+        filename = '16_attr_ref_single-multi.data'
+        filepath = test_file_path + filename
+
+        # Test File Import
+        file_import = sfcparse.importfile(filepath)
+
+        # Test Attributes and Types
+        self.assertEqual(file_import.data_list_multi, 1)
+        self.assertEqual(file_import.data_float, {'k1':1, 'k2':2, 'k3':3})
+        self.assertEqual(file_import.data_bool, {'k1':1, 'k2':2, 'k3':3})
+        self.assertEqual(file_import.data_set, (1,2,3))
+    
+    # 17. Attr Referencing Lock - Reference Pre-Defined Attr's Value, Confirm Assigned, and Locked
+    def test17_attr_ref_lock_single_multi(self):
+        filename = '17_attr_ref_lock_single-multi.data'
+        filepath = test_file_path + filename
+
+        # Test File Import
+        file_import = sfcparse.importfile(filepath)
+
+        # Test Attributes and Types - Locked Values Check, then Test Re-Assignment
+        change_value = 'changed_value'
+        
+        self.assertEqual(file_import.data_list_multi, 1)
+        with self.assertRaises(Exception): file_import.data_list_multi = change_value
+
+        self.assertEqual(file_import.data_float, {'k1':1, 'k2':2, 'k3':3})
+        with self.assertRaises(Exception): file_import.data_float = change_value
+
+        self.assertEqual(file_import.data_bool, {'k1':1, 'k2':2, 'k3':3})
+        with self.assertRaises(Exception): file_import.data_bool = change_value
+
+        self.assertEqual(file_import.data_set, (1,2,3))
+        with self.assertRaises(Exception): file_import.data_set = change_value

--- a/tests/test_files/native/importfile_files/15_attr_lock_mixed_imports.data
+++ b/tests/test_files/native/importfile_files/15_attr_lock_mixed_imports.data
@@ -4,7 +4,7 @@ data_list_multi $= [
     2,
     3
 ]
-data_dict = {
+data_dict_multi = {
     'k1': 1,
     'k2': 2,
     'k3': 3
@@ -12,12 +12,12 @@ data_dict = {
 data_float $= 1.0
 data_bool $= True
 data_list = [1,2,3]
-data_tuple = (
+data_tuple_multi = (
     1,
     2,
     3
 )
-data_set $= {
+data_set_multi $= {
     1,
     2,
     3

--- a/tests/test_files/native/importfile_files/15_attr_lock_mixed_imports.data
+++ b/tests/test_files/native/importfile_files/15_attr_lock_mixed_imports.data
@@ -1,0 +1,25 @@
+data_int = 1
+data_list_multi $= [
+    1,
+    2,
+    3
+]
+data_dict = {
+    'k1': 1,
+    'k2': 2,
+    'k3': 3
+}
+data_float $= 1.0
+data_bool $= True
+data_list = [1,2,3]
+data_tuple = (
+    1,
+    2,
+    3
+)
+data_set $= {
+    1,
+    2,
+    3
+}
+

--- a/tests/test_files/native/importfile_files/16_attr_ref_single-multi.data
+++ b/tests/test_files/native/importfile_files/16_attr_ref_single-multi.data
@@ -1,0 +1,16 @@
+data_int = 1
+data_list_multi == data_int # Comment Test
+data_dict = {
+    'k1': 1,
+    'k2': 2,
+    'k3': 3
+}
+data_float == data_dict# Comment Test
+data_bool == data_float#Comment Test
+data_list = [1,2,3]
+data_tuple = (
+    1,
+    2,
+    3
+)
+data_set == data_tuple #Comment Test

--- a/tests/test_files/native/importfile_files/17_attr_ref_lock_single-multi.data
+++ b/tests/test_files/native/importfile_files/17_attr_ref_lock_single-multi.data
@@ -1,0 +1,16 @@
+data_int = 1
+data_list_multi $== data_int # Comment Test
+data_dict = {
+    'k1': 1,
+    'k2': 2,
+    'k3': 3
+}
+data_float $== data_dict# Comment Test
+data_bool $== data_float#Comment Test
+data_list = [1,2,3]
+data_tuple = (
+    1,
+    2,
+    3
+)
+data_set $== data_tuple #Comment Test


### PR DESCRIPTION
- New Feature for importfile: Attribute Name Referencing
Allows the ability to explicitly reference other attribute values by their names in the file. 
This is good for something like templating data structures to reference without modification of the template.