### PR TITLE
v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The easy to use library for your data, configuration, and save files
 
 [![Functionality-QA-Tests](https://github.com/aaronater10/sfcparse/actions/workflows/sfcparse_functionality_testing.yml/badge.svg)](https://github.com/aaronater10/sfcparse/actions/workflows/sfcparse_functionality_testing.yml)
 
-##### Latest Version: 1.3.2
+##### Latest Version: 2.0.0
 
 #
 

--- a/deploy/build_deploy_sfcparse.py
+++ b/deploy/build_deploy_sfcparse.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 
 # Setup
-SFCPARSE_VERSION = "1.3.2"
+SFCPARSE_VERSION = "2.0.0"
 DEPLOY_API_TOKEN = f"{sys.argv[1]}"
 DEPLOY_SSH_KEY = f"{sys.argv[2]}"
 USER_HOMEPATH = os.getenv('HOME')

--- a/src/sfcparse/__hash/comparefilehash.py
+++ b/src/sfcparse/__hash/comparefilehash.py
@@ -3,10 +3,7 @@
 # Imports
 from .createfilehash import createfilehash
 from ..__native.importfile import importfile
-from ..error import SfcparseError
-
-# Exception for Module
-class CompareFileHash(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import CompareFileHash
 
 #########################################################################################################
 # Compare file hashes

--- a/src/sfcparse/__hash/createfilehash.py
+++ b/src/sfcparse/__hash/createfilehash.py
@@ -5,10 +5,7 @@ from ..__native.importfileraw import importfileraw
 from ..__native.exportfile import exportfile
 from typing import Union as __Union
 import hashlib as __hashlib
-from ..error import SfcparseError
-
-# Exception for Module
-class CreateFileHash(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import CreateFileHash
 
 #########################################################################################################
 # Create file hash

--- a/src/sfcparse/__ini/inibuildauto.py
+++ b/src/sfcparse/__ini/inibuildauto.py
@@ -3,10 +3,7 @@
 # Imports
 from configparser import ConfigParser as __ConfigParser
 from configparser import ExtendedInterpolation as __ExtendedInterpolation
-from ..error import SfcparseError
-
-# Exception for Module
-class IniBuildAuto(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import IniBuildAuto
 
 #########################################################################################################
 # Auto Build ini data

--- a/src/sfcparse/__ini/iniexportfile.py
+++ b/src/sfcparse/__ini/iniexportfile.py
@@ -2,10 +2,7 @@
 #########################################################################################################
 # Imports
 from configparser import ConfigParser as __ConfigParser
-from ..error import SfcparseError
-
-# Exception for Module
-class IniExportFile(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import IniExportFile
 
 #########################################################################################################
 # Export ini file

--- a/src/sfcparse/__ini/iniimportfile.py
+++ b/src/sfcparse/__ini/iniimportfile.py
@@ -3,10 +3,7 @@
 # Imports
 from configparser import ConfigParser as __ConfigParser
 from configparser import ExtendedInterpolation as __ExtendedInterpolation
-from ..error import SfcparseError
-
-# Exception for Module
-class IniImportFile(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import IniImportFile
 
 #########################################################################################################
 # Import ini file

--- a/src/sfcparse/__init__.py
+++ b/src/sfcparse/__init__.py
@@ -1,7 +1,7 @@
 """
 Simple File Configuration Parse - by aaronater10
 
-Version 1.3.2
+Version 2.0.0
 
 The easy to use library for your data, configuration, and save files.
 

--- a/src/sfcparse/__init__.py
+++ b/src/sfcparse/__init__.py
@@ -26,6 +26,7 @@ from .__native.exportfile import exportfile
 from .__native.appendfile import appendfile
 from .__native.cleanformat import cleanformat
 from .__native.savefile import savefile
+from .__native.builddata import builddata
 
 # Hash Lib
 from .__hash.createfilehash import createfilehash

--- a/src/sfcparse/__init__.py
+++ b/src/sfcparse/__init__.py
@@ -18,6 +18,7 @@ Source Code: https://github.com/aaronater10/sfcparse
 # Native Lib
 from .__native.importfile import importfile
 from .__native.importfileraw import importfileraw
+from .__native.importattrs import importattrs
 from .__native.exportfile import exportfile
 from .__native.appendfile import appendfile
 from .__native.cleanformat import cleanformat

--- a/src/sfcparse/__init__.py
+++ b/src/sfcparse/__init__.py
@@ -21,6 +21,7 @@ from .__native.importfileraw import importfileraw
 from .__native.exportfile import exportfile
 from .__native.appendfile import appendfile
 from .__native.cleanformat import cleanformat
+from .__native.savefile import savefile
 
 # Hash Lib
 from .__hash.createfilehash import createfilehash

--- a/src/sfcparse/__init__.py
+++ b/src/sfcparse/__init__.py
@@ -15,6 +15,9 @@ Source Code: https://github.com/aaronater10/sfcparse
 #########################################################################################################
 # Imports
 
+# Base Exceptions
+from . import error
+
 # Native Lib
 from .__native.importfile import importfile
 from .__native.importfileraw import importfileraw

--- a/src/sfcparse/__json/jsonexportfile.py
+++ b/src/sfcparse/__json/jsonexportfile.py
@@ -2,11 +2,8 @@
 #########################################################################################################
 # Imports
 import json as __json
-from ..error import SfcparseError
+from ..error import JsonExportFile
 from typing import Union
-
-# Exception for Module
-class JsonExportFile(SfcparseError): __module__ = SfcparseError.set_module_name()
 
 #########################################################################################################
 # Export json file

--- a/src/sfcparse/__json/jsonexportstr.py
+++ b/src/sfcparse/__json/jsonexportstr.py
@@ -2,11 +2,8 @@
 #########################################################################################################
 # Imports
 import json as __json
-from ..error import SfcparseError
+from ..error import JsonExportStr
 from typing import Union
-
-# Exception for Module
-class JsonExportStr(SfcparseError): __module__ = SfcparseError.set_module_name()
 
 #########################################################################################################
 # Export json str

--- a/src/sfcparse/__json/jsonimportfile.py
+++ b/src/sfcparse/__json/jsonimportfile.py
@@ -2,11 +2,8 @@
 #########################################################################################################
 # Imports
 import json as __json
-from ..error import SfcparseError
+from ..error import JsonImportFile
 from typing import Union
-
-# Exception for Module
-class JsonImportFile(SfcparseError): __module__ = SfcparseError.set_module_name()
 
 #########################################################################################################
 # Import json file

--- a/src/sfcparse/__json/jsonimportstr.py
+++ b/src/sfcparse/__json/jsonimportstr.py
@@ -2,11 +2,8 @@
 #########################################################################################################
 # Imports
 import json as __json
-from ..error import SfcparseError
+from ..error import JsonImportStr
 from typing import Union
-
-# Exception for Module
-class JsonImportStr(SfcparseError): __module__ = SfcparseError.set_module_name()
 
 #########################################################################################################
 # Import json string

--- a/src/sfcparse/__native/appendfile.py
+++ b/src/sfcparse/__native/appendfile.py
@@ -3,10 +3,7 @@
 # Imports
 from typing import Any as __Any
 from os import path as __path
-from ..error import SfcparseError
-
-# Exception for Module
-class AppendFile(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import AppendFile
 
 #########################################################################################################
 # Append Data to File

--- a/src/sfcparse/__native/builddata.py
+++ b/src/sfcparse/__native/builddata.py
@@ -1,0 +1,24 @@
+# builddata
+#########################################################################################################
+# Imports
+from .importfile import SfcparseFileData
+
+#########################################################################################################
+# Build manual SfcparseFileData (python data)
+def builddata() -> SfcparseFileData:
+    """
+    Returns an empty SfcparseFileData obj to manually build python data with sfcparse features
+    
+    Assign the output to var
+
+    Literally just use attribute assignment as you normally would
+
+    [Example]
+
+    object.attribute1 = [1,2,3]
+
+    object.attribute2 = 'string data'
+
+    More information on object features: https://docs.sfcparse.org/docs/tools/build-data/python-data-build
+    """
+    return SfcparseFileData('', True, True)

--- a/src/sfcparse/__native/cleanformat.py
+++ b/src/sfcparse/__native/cleanformat.py
@@ -2,10 +2,7 @@
 #########################################################################################################
 # Imports
 from typing import Union as __Union
-from ..error import SfcparseError
-
-# Exception for Module
-class CleanFormat(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import CleanFormat
 
 #########################################################################################################
 # Format/Prep Dictionary, List, Tuple, or Set Data for Export

--- a/src/sfcparse/__native/exportfile.py
+++ b/src/sfcparse/__native/exportfile.py
@@ -2,10 +2,7 @@
 #########################################################################################################
 # Imports
 from typing import Any as __Any
-from ..error import SfcparseError
-
-# Exception for Module
-class ExportFile(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import ExportFile
 
 #########################################################################################################
 # Export Data to File

--- a/src/sfcparse/__native/importattrs.py
+++ b/src/sfcparse/__native/importattrs.py
@@ -1,11 +1,8 @@
 # importattrs
 #########################################################################################################
 # Imports
-from ..error import SfcparseError
+from ..error import ImportAttrs
 from .importfile import importfile as __importfile
-
-# Exception for Module
-class ImportAttrs(SfcparseError): __module__ = SfcparseError.set_module_name()
 
 #########################################################################################################
 # Import Attributes from File

--- a/src/sfcparse/__native/importattrs.py
+++ b/src/sfcparse/__native/importattrs.py
@@ -1,8 +1,9 @@
 # importattrs
 #########################################################################################################
 # Imports
-from ..error import ImportAttrs
+from ..error import ImportAttrs, ImportFile
 from .importfile import importfile as __importfile
+from .importfile import SfcparseFileData as __SfcparseFileData
 
 #########################################################################################################
 # Import Attributes from File
@@ -13,14 +14,46 @@ def importattrs(filename: str, class_object: '__SfcparseDummy.Class') -> None:
     """
     importattrs - done in-place
     """
+    # Error Checks
+    __err_msg_type_str_filename = "Only str is allowed for filename"
+    __err_msg_type_class_obj = "Only a custom class object is allowed for class_object"
+    __err_msg_type_sfcparse_obj = "Please use 'importfile' function to properly import a SfcparseFileData object"
+
+    if not isinstance(filename, str): raise ImportAttrs(__err_msg_type_str_filename, f'\nFILE: "{filename}"')
     
-    # Keys
-    __skip_object_key = '_SfcparseFileData'
+    if (isinstance(class_object, str)) \
+    or (isinstance(class_object, int)) \
+    or (isinstance(class_object, float)) \
+    or (isinstance(class_object, bool)) \
+    or (isinstance(class_object, list)) \
+    or (isinstance(class_object, tuple)) \
+    or (isinstance(class_object, set)) \
+    or (isinstance(class_object, dict)) \
+    or (isinstance(class_object, type(None))) \
+    or (isinstance(class_object, bytes)) \
+    or (isinstance(class_object, complex)) \
+    or (isinstance(class_object, range)) \
+    or (isinstance(class_object, frozenset)) \
+    or (isinstance(class_object, bytearray)) \
+    or (isinstance(class_object, memoryview)):
+        raise ImportAttrs(__err_msg_type_class_obj, f'\nFILE: "{filename}" \nDATA: {class_object}')
+
+    if isinstance(class_object, __SfcparseFileData):
+        raise ImportAttrs(__err_msg_type_sfcparse_obj, f'\nFILE: "{filename}" \nDATA: {class_object}')
+
 
     # Import Attrs from File and Inject into Given Class Object
-    __imported_data = __importfile(filename)
-    for key,value in __imported_data.__dict__.items():
-        if key.startswith(__skip_object_key): continue
-        setattr(class_object, key, value)
-    
+
+    # Skip Key
+    __skip_object_key = ('_SfcparseFileData', '__sfcparse_file_format_id')
+
+    # Import Attrs
+    try:
+        __imported_data = __importfile(filename)
+        for key,value in __imported_data.__dict__.items():
+            if key.startswith(__skip_object_key): continue
+            setattr(class_object, key, value)
+    except ImportFile as __err_msg:
+        raise ImportAttrs(__err_msg, '')
+
     return None

--- a/src/sfcparse/__native/importattrs.py
+++ b/src/sfcparse/__native/importattrs.py
@@ -12,7 +12,13 @@ class __SfcparseDummy:
 
 def importattrs(filename: str, class_object: '__SfcparseDummy.Class') -> None:
     """
-    importattrs - done in-place
+    Import saved attributes from file back into a custom class. This is done in-place
+
+    Enter filename as str, Pass custom class object.
+
+    [Example Use]
+
+    importattrs('path/of/filename', 'class_object')
     """
     # Error Checks
     __err_msg_type_str_filename = "Only str is allowed for filename"

--- a/src/sfcparse/__native/importattrs.py
+++ b/src/sfcparse/__native/importattrs.py
@@ -1,0 +1,29 @@
+# importattrs
+#########################################################################################################
+# Imports
+from ..error import SfcparseError
+from .importfile import importfile as __importfile
+
+# Exception for Module
+class ImportAttrs(SfcparseError): __module__ = SfcparseError.set_module_name()
+
+#########################################################################################################
+# Import Attributes from File
+class __SfcparseDummy:
+    class Class: """dummy class for hinting"""
+
+def importattrs(filename: str, class_object: '__SfcparseDummy.Class') -> None:
+    """
+    importattrs - done in-place
+    """
+    
+    # Keys
+    __skip_object_key = '_SfcparseFileData'
+
+    # Import Attrs from File and Inject into Given Class Object
+    __imported_data = __importfile(filename)
+    for key,value in __imported_data.__dict__.items():
+        if key.startswith(__skip_object_key): continue
+        setattr(class_object, key, value)
+    
+    return None

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -15,6 +15,10 @@ class SfcparseFileData:
         self.__assignment_reference_attribs = {}
         self.__attrib_name_dedup = attrib_name_dedup
 
+        # One Time Generated using UUID4 mode from UUID Library.
+        # This helps authenticity of SfcparseFileData Object for Development aid
+        self.__sfcparse_file_format_id__ = "a55acb6b-f87b-4f89-ad11-c9d23eb1307d-7797537e-fb5d-4c69-b84f-2b4da59c04c1"
+
         # Open and Import Config File into Class Object then return the object        
         with open(filename, 'r') as f:
             f = f.read().splitlines()

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -4,7 +4,7 @@
 from ast import literal_eval as __literal_eval__
 from os import path as __path
 from typing import Any as _Any
-from ..error import ImportFile
+from ..error import ImportFile, GeneralError
 
 #########################################################################################################
 # Import py Data from File
@@ -176,6 +176,46 @@ class SfcparseFileData:
             self.__dict__[_name] = _orig_value
             # RAISE EXCEPTION
             raise ImportFile(self.__assignment_locked_atrribs_err_msg, f'\nATTRIB_NAME: "{_name}"')
+
+
+    def lock_attr(self, attr_name: str) -> None:
+        """
+        Lock's a class attribute name from re-assignment
+        """
+        # Error Checks
+        __err_msg_attr_name_str = "Only str is allowed for attr_name"
+        __err_msg_attr_name_exist = "Attribute name does not exist! Must be created first to lock"
+
+        if not isinstance(attr_name, str): raise GeneralError(__err_msg_attr_name_str, f'\nATTR_NAME: "{attr_name}"')
+        if not self.__dict__.get(attr_name): raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')
+
+        # Assign Attr to Locked List
+        self.__assignment_locked_attribs.append(attr_name)
+    
+    
+    def reference_attr(self, attr_name: str, reference_name: str) -> None:
+        """
+        Create reference of class attribute name to another attribute name value from this object
+
+        This will also assign the value of the reference name to the attribute
+        """
+        # Error Checks
+        __err_msg_attr_name_str = "Only str is allowed for attr_name"
+        __err_msg_reference_name_str = "Only str is allowed for reference_name"
+        __err_msg_attr_name_exist = "Source attribute name does not exist! Must be created first to assign reference"
+        __err_msg_reference_name_exist = "Reference attribute name does not exist! Cannot assign value reference"
+
+        if not isinstance(attr_name, str): raise GeneralError(__err_msg_attr_name_str, f'\nATTR_NAME: "{attr_name}"')
+        if not isinstance(reference_name, str): raise GeneralError(__err_msg_reference_name_str, f'\nATTR_NAME: "{reference_name}"')
+
+        # Look up if Attr or Reference Name Exists
+        if not self.__dict__.get(attr_name): raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')
+        if not self.__dict__.get(reference_name): raise GeneralError(__err_msg_reference_name_exist, f'\nATTR_NAME: "{reference_name}"')
+
+        # Assign Attr Name to Reference Name in Reference Dict
+        self.__assignment_reference_attribs[attr_name] = reference_name
+        # Set Value to Reference Value
+        setattr(self, attr_name, getattr(self, reference_name))
 
 
 def importfile(filename: str, attrib_name_dedup: bool=True) -> 'SfcparseFileData':

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -188,7 +188,7 @@ class SfcparseFileData:
         """
         # Error Checks
         __err_msg_attr_name_str = "Only str is allowed for attr_name"
-        __err_msg_attr_name_exist = "Attribute name does not exist! Must be created first to lock"
+        __err_msg_attr_name_exist = "Locked attribute name does not exist! Must be created first to lock"
 
         if not isinstance(attr_name, str): raise GeneralError(__err_msg_attr_name_str, f'\nATTR_NAME: "{attr_name}"')
         if not self.__dict__.get(attr_name): raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')
@@ -203,8 +203,8 @@ class SfcparseFileData:
         """
         # Error Checks
         __err_msg_attr_name_str = "Only str is allowed for attr_name"
-        __err_msg_attr_name_exist = "Attribute name does not exist! Must be created first to lock"
-        __err_msg_attr_name_exist_unlock = "Attribute name does not exist! Could not find name to unlock"
+        __err_msg_attr_name_exist = "Unlock attribute name does not exist"
+        __err_msg_attr_name_exist_unlock = "Unlock attribute name does not exist in lock! Could not find name to unlock"
 
         if not isinstance(attr_name, str): raise GeneralError(__err_msg_attr_name_str, f'\nATTR_NAME: "{attr_name}"')
         if not self.__dict__.get(attr_name): raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -15,6 +15,7 @@ class SfcparseFileData:
     def __init__(self, filename: str, attrib_name_dedup: bool):
         # '__assignment_locked_attribs' MUST BE FIRST INIT ASSIGNMENT
         self.__assignment_locked_attribs = []
+        self.__assignment_reference_attribs = {}
         self.__attrib_name_dedup = attrib_name_dedup
 
         # Open and Import Config File into Class Object then return the object        
@@ -128,11 +129,15 @@ class SfcparseFileData:
                         
                         # Check if Attr is a Reference to Another Attr's Value for Assignment. Ignore Comments
                         if __current_assignment_operator == __assignment_operator_markers[2]:
-                            setattr(self, __var_token, getattr(self, f"{__value_token} "[:__value_token.find(__skip_markers[2])].rstrip()))
+                            __value_token = f"{__value_token} "[:__value_token.find(__skip_markers[2])].rstrip()
+                            self.__assignment_reference_attribs[__var_token] = __value_token
+                            setattr(self, __var_token, getattr(self, __value_token))
                             continue
                         # Check if Attr is a Reference to Another Attr's Value for Assignment and Locked from Re-Assignment. Ignore Comments
                         if __current_assignment_operator == __assignment_operator_markers[3]:
-                            setattr(self, __var_token, getattr(self, f"{__value_token} "[:__value_token.find(__skip_markers[2])].rstrip()))
+                            __value_token = f"{__value_token} "[:__value_token.find(__skip_markers[2])].rstrip()
+                            self.__assignment_reference_attribs[__var_token] = __value_token
+                            setattr(self, __var_token, getattr(self, __value_token))
                             self.__assignment_locked_attribs.append(__var_token)
                             continue
 

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -4,10 +4,7 @@
 from ast import literal_eval as __literal_eval__
 from os import path as __path
 from typing import Any as _Any
-from ..error import SfcparseError
-
-# Exception for Module
-class ImportFile(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import ImportFile
 
 #########################################################################################################
 # Import py Data from File

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -131,14 +131,14 @@ class SfcparseFileData:
                         # Check if Attr is a Reference to Another Attr's Value for Assignment. Ignore Comments
                         if __current_assignment_operator == __assignment_operator_markers[2]:
                             __value_token = f"{__value_token} "[:__value_token.find(__skip_markers[2])].rstrip()
-                            self.__assignment_reference_attribs[__var_token] = __value_token
                             setattr(self, __var_token, getattr(self, __value_token))
+                            self.__assignment_reference_attribs[__var_token] = __value_token
                             continue
                         # Check if Attr is a Reference to Another Attr's Value for Assignment and Locked from Re-Assignment. Ignore Comments
                         if __current_assignment_operator == __assignment_operator_markers[3]:
                             __value_token = f"{__value_token} "[:__value_token.find(__skip_markers[2])].rstrip()
-                            self.__assignment_reference_attribs[__var_token] = __value_token
                             setattr(self, __var_token, getattr(self, __value_token))
+                            self.__assignment_reference_attribs[__var_token] = __value_token
                             self.__assignment_locked_attribs.append(__var_token)
                             continue
 
@@ -166,6 +166,10 @@ class SfcparseFileData:
         if _name in self.__dict__:
             _orig_value = self.__dict__.get(_name)
             
+        # Release Attribute Reference if Name is Re-Assigned
+        if _name in self.__dict__:
+            self.__reference_deletion_check(_name)
+
         # Always Assign Value 
         self.__dict__[_name] = _new_value
 
@@ -212,10 +216,20 @@ class SfcparseFileData:
         if not self.__dict__.get(attr_name): raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')
         if not self.__dict__.get(reference_name): raise GeneralError(__err_msg_reference_name_exist, f'\nATTR_NAME: "{reference_name}"')
 
-        # Assign Attr Name to Reference Name in Reference Dict
-        self.__assignment_reference_attribs[attr_name] = reference_name
         # Set Value to Reference Value
         setattr(self, attr_name, getattr(self, reference_name))
+    
+        # Assign Attr Name to Reference Name in Reference Dict
+        self.__assignment_reference_attribs[attr_name] = reference_name
+
+
+    def __reference_deletion_check(self, _name: str):
+        """
+        Internal method: check if reference requires deletion from reference list
+        if attribute is attempted to be re-assigned
+        """
+        if _name in self.__assignment_reference_attribs.keys():
+            self.__assignment_reference_attribs.pop(_name, None)
 
 
 def importfile(filename: str, attrib_name_dedup: bool=True) -> 'SfcparseFileData':

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -9,7 +9,7 @@ from ..error import ImportFile, GeneralError
 #########################################################################################################
 # Import py Data from File
 class SfcparseFileData:
-    def __init__(self, filename: str, attrib_name_dedup: bool):
+    def __init__(self, filename: str, attrib_name_dedup: bool, __is_build_request: bool = False):
         # '__assignment_locked_attribs' MUST BE FIRST INIT ASSIGNMENT
         self.__assignment_locked_attribs = []
         self.__assignment_reference_attribs = {}
@@ -19,15 +19,19 @@ class SfcparseFileData:
         # This helps authenticity of SfcparseFileData Object for Development aid
         self.__sfcparse_file_format_id__ = "a55acb6b-f87b-4f89-ad11-c9d23eb1307d-7797537e-fb5d-4c69-b84f-2b4da59c04c1"
 
-        # Open and Import Config File into Class Object then return the object        
-        with open(filename, 'r') as f:
-            f = f.read().splitlines()
-
         # Syntax/Usage Error Messages
         __py_syntax_err_msg = "Must have valid Python data types to import, or file's syntax is not formatted correctly"
         __name_preexists_err_msg = "Name already preexists. Must give unique attribute names in file"
         __name_reference_does_not_exist = "Name reference does not exist! Must reference attribute names in file that have been defined"
         self.__assignment_locked_atrribs_err_msg = "Value Locked! Attribute cannot be reassigned"
+
+        # BUILD REQUEST: If this is a object build request,
+        # then end the INIT here with above self.attributes intact
+        if __is_build_request: return None
+
+        # Open and Import Config File into Class Object then return the object        
+        with open(filename, 'r') as f:
+            f = f.read().splitlines()
         
         # Data Build Setup and Switches        
         __is_building_data_sw = False
@@ -191,7 +195,7 @@ class SfcparseFileData:
         __err_msg_attr_name_exist = "Locked attribute name does not exist! Must be created first to lock"
 
         if not isinstance(attr_name, str): raise GeneralError(__err_msg_attr_name_str, f'\nATTR_NAME: "{attr_name}"')
-        if not self.__dict__.get(attr_name): raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')
+        if not attr_name in self.__dict__: raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')
 
         # Assign Attr to Locked List
         self.__assignment_locked_attribs.append(attr_name)
@@ -207,7 +211,7 @@ class SfcparseFileData:
         __err_msg_attr_name_exist_unlock = "Unlock attribute name does not exist in lock! Could not find name to unlock"
 
         if not isinstance(attr_name, str): raise GeneralError(__err_msg_attr_name_str, f'\nATTR_NAME: "{attr_name}"')
-        if not self.__dict__.get(attr_name): raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')
+        if not attr_name in self.__dict__: raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')
 
         # Remove Attr from Locked List
         try: self.__assignment_locked_attribs.remove(attr_name)
@@ -219,6 +223,8 @@ class SfcparseFileData:
         Create reference of class attribute name to another attribute name value from this object
 
         This will also assign the value of the reference name to the attribute
+
+        Useful to maintain name references stored to a file
         """
         # Error Checks
         __err_msg_attr_name_str = "Only str is allowed for attr_name"
@@ -230,8 +236,8 @@ class SfcparseFileData:
         if not isinstance(reference_name, str): raise GeneralError(__err_msg_reference_name_str, f'\nATTR_NAME: "{reference_name}"')
 
         # Look up if Attr or Reference Name Exists
-        if not self.__dict__.get(attr_name): raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')
-        if not self.__dict__.get(reference_name): raise GeneralError(__err_msg_reference_name_exist, f'\nATTR_NAME: "{reference_name}"')
+        if not attr_name in self.__dict__: raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')
+        if not reference_name in self.__dict__: raise GeneralError(__err_msg_reference_name_exist, f'\nATTR_NAME: "{reference_name}"')
 
         # Set Value to Reference Value
         setattr(self, attr_name, getattr(self, reference_name))

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -11,7 +11,7 @@ class ImportFile(SfcparseError): __module__ = SfcparseError.set_module_name()
 
 #########################################################################################################
 # Import py Data from File
-class FileData:
+class SfcparseFileData:
     def __init__(self, filename: str, attrib_name_dedup: bool):
         # '__assignment_locked_attribs' MUST BE FIRST INIT ASSIGNMENT
         self.__assignment_locked_attribs = []
@@ -172,7 +172,7 @@ class FileData:
             raise ImportFile(self.__assignment_locked_atrribs_err_msg, f'\nATTRIB_NAME: "{_name}"')
 
 
-def importfile(filename: str, attrib_name_dedup: bool=True) -> 'FileData':
+def importfile(filename: str, attrib_name_dedup: bool=True) -> 'SfcparseFileData':
     """
     Imports saved python data from any text file.
 
@@ -201,4 +201,4 @@ def importfile(filename: str, attrib_name_dedup: bool=True) -> 'FileData':
     except FileNotFoundError as __err_msg: raise ImportFile(__err_msg, f'\nFILE: "{filename}"')
 
     # Return Final Import
-    return FileData(filename, attrib_name_dedup)
+    return SfcparseFileData(filename, attrib_name_dedup)

--- a/src/sfcparse/__native/importfile.py
+++ b/src/sfcparse/__native/importfile.py
@@ -195,8 +195,25 @@ class SfcparseFileData:
 
         # Assign Attr to Locked List
         self.__assignment_locked_attribs.append(attr_name)
-    
-    
+
+
+    def unlock_attr(self, attr_name: str) -> None:
+        """
+        Unlocks a class attribute name from locked re-assignment
+        """
+        # Error Checks
+        __err_msg_attr_name_str = "Only str is allowed for attr_name"
+        __err_msg_attr_name_exist = "Attribute name does not exist! Must be created first to lock"
+        __err_msg_attr_name_exist_unlock = "Attribute name does not exist! Could not find name to unlock"
+
+        if not isinstance(attr_name, str): raise GeneralError(__err_msg_attr_name_str, f'\nATTR_NAME: "{attr_name}"')
+        if not self.__dict__.get(attr_name): raise GeneralError(__err_msg_attr_name_exist, f'\nATTR_NAME: "{attr_name}"')
+
+        # Remove Attr from Locked List
+        try: self.__assignment_locked_attribs.remove(attr_name)
+        except ValueError: raise GeneralError(__err_msg_attr_name_exist_unlock, f'\nATTR_NAME: "{attr_name}"')
+
+
     def reference_attr(self, attr_name: str, reference_name: str) -> None:
         """
         Create reference of class attribute name to another attribute name value from this object

--- a/src/sfcparse/__native/importfileraw.py
+++ b/src/sfcparse/__native/importfileraw.py
@@ -2,10 +2,7 @@
 #########################################################################################################
 # Imports
 from os import path as __path
-from ..error import SfcparseError
-
-# Exception for Module
-class ImportFileRaw(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import ImportFileRaw
 
 #########################################################################################################
 # Import raw data from file

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -3,7 +3,8 @@
 # Imports
 from ast import literal_eval as __literal_eval__
 from typing import Union as __Union
-from ..error import SaveFile
+from typing import Any as __Any
+from ..error import SaveFile, ExportFile, AppendFile
 from .importfile import SfcparseFileData as __SfcparseFileData
 from .exportfile import exportfile as __exportfile
 from .appendfile import appendfile as __appendfile
@@ -24,6 +25,18 @@ def savefile(
     """
     savefile
     """
+    # Error Checks
+    __err_msg_general_error = "Error has occurred and cannot proceed"
+    __err_msg_type_str_filename = "Only str is allowed for filename"
+    __err_msg_type_str_write_mode = "Only str is allowed for write_mode"
+    __err_msg_type_int_indent_level = "Only int is allowed for indent_level"
+    __err_msg_type_bool_indentation_on = "Only bool is allowed for indentation_on"
+
+    if not isinstance(filename, str): raise SaveFile(__err_msg_type_str_filename, f'\nFILE: "{filename}"')
+    if not isinstance(write_mode, str): raise SaveFile(__err_msg_type_str_write_mode, f'\nFILE: "{filename}" \nDATA: {write_mode}')
+    if not isinstance(indent_level, int): raise SaveFile(__err_msg_type_int_indent_level, f'\nFILE: "{filename}" \nDATA: {indent_level}')
+    if not isinstance(indentation_on, bool): raise SaveFile(__err_msg_type_bool_indentation_on, f'\nFILE: "{filename}" \nDATA: {indentation_on}')
+
     
     # Save Data to File
     __build_data_output = ""
@@ -63,12 +76,8 @@ def savefile(
         # Strip Last \n Char
         __build_data_output = __build_data_output.rstrip()
 
-        # Write New File Mode
-        if write_mode == 'w':
-            __exportfile(filename, __build_data_output)
-        # Append Append File Mode
-        if write_mode == 'a':
-            __appendfile(filename, __build_data_output)
+        # Write File Data
+        __write_file_data(filename, __build_data_output, write_mode)
 
         return None
 
@@ -89,12 +98,8 @@ def savefile(
         # Strip Last \n Char
         __build_data_output = __build_data_output.rstrip()
 
-        # Write New File Mode
-        if write_mode == 'w':
-            __exportfile(filename, __build_data_output)
-        # Append Append File Mode
-        if write_mode == 'a':
-            __appendfile(filename, __build_data_output)
+        # Write File Data
+        __write_file_data(filename, __build_data_output, write_mode)
 
         return None
 
@@ -125,21 +130,24 @@ def savefile(
         # Strip Last \n Char
         __build_data_output = __build_data_output.rstrip()
 
-        # Write New File Mode
-        if write_mode == 'w':
-            __exportfile(filename, __build_data_output)
-        # Append Append File Mode
-        if write_mode == 'a':
-            __appendfile(filename, __build_data_output)
+        # Write File Data
+        __write_file_data(filename, __build_data_output, write_mode)
 
         return None
 
 
-    # Report if required types not correct
+    # Report if Error not Definable
+    raise SaveFile(__err_msg_general_error, f'\nDATA: {data}')
+
 
 #########################################################################################################
 # Functions
+
+# Multiline Check
 def __multiline_check(data: __Union[list, dict, tuple, set]) -> bool:
+    """
+    Check if Multiline Type to Assist for Indentation
+    """
     if isinstance(data, list) \
     or isinstance(data, dict) \
     or isinstance(data, tuple) \
@@ -147,3 +155,22 @@ def __multiline_check(data: __Union[list, dict, tuple, set]) -> bool:
         return True
     return False
 
+# Write File Data
+def __write_file_data(filename: str, data: __Any, write_mode: str) -> None:
+    """
+    Write New or Append Data to File
+    """
+    __err_msg_write_mode = 'Bad write mode'
+    __write_mode_allowed_list = ['w', 'a']
+    try:
+        # Write New File Mode
+        if write_mode == 'w':
+            __exportfile(filename, data)
+        # Append Append File Mode
+        if write_mode == 'a':
+            __appendfile(filename, data)        
+        # Raise Exception if No Match
+        if not write_mode in __write_mode_allowed_list:
+            raise SaveFile(__err_msg_write_mode, f'\nFILE: "{filename}" \nDATA: {write_mode}')
+    except ExportFile as __err: raise SaveFile(__err, '')
+    except AppendFile as __err: raise SaveFile(__err, '')

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -6,14 +6,101 @@ from os import path as __path
 from typing import Union as __Union
 from ..error import SfcparseError
 from .importfile import SfcparseFileData as __SfcparseFileData
+from .exportfile import exportfile as __exportfile
+from .appendfile import appendfile as __appendfile
+from .cleanformat import cleanformat as __cleanformat
 
 # Exception for Module
 class SaveFile(SfcparseError): __module__ = SfcparseError.set_module_name()
 
 #########################################################################################################
 # Save Data to File
-def savefile(filename: str, data: __Union['__SfcparseFileData', dict]) -> None:
+def savefile(
+    filename: str, 
+    data: __Union['__SfcparseFileData', dict], 
+    write_mode: str = 'w',
+    indent_level: int = 1,
+    indentation_on: bool = True
+    ) -> None:
     """
     savefile
     """
-    pass
+    
+    # Save Data to File
+    __build_data_output = ""
+    __assignment_operators = ('=', '$=', '==', '$==')
+    __skip_object_key = '_SfcparseFileData'
+    __locked_attr_list_key =  '_SfcparseFileData__assignment_locked_attribs'
+    __reference_attr_list_key =  '_SfcparseFileData__assignment_reference_attribs'
+
+    # Check if SfcparseFileData
+    if isinstance(data, __SfcparseFileData):
+        # Build Data
+        for key,value in data.__dict__.items():
+            if not key.startswith(__skip_object_key):
+                # Check Operator Type and Build Accordingly
+
+                # Reference and Locked
+                if (key in data.__dict__[__reference_attr_list_key]) and (key in data.__dict__[__locked_attr_list_key]):
+                    __build_data_output += f'{key} {__assignment_operators[3]} {data.__dict__[__reference_attr_list_key][key]}\n'
+                    continue
+                # Reference Only
+                if key in data.__dict__[__reference_attr_list_key]:
+                    __build_data_output += f'{key} {__assignment_operators[2]} {data.__dict__[__reference_attr_list_key][key]}\n'
+                    continue
+                # Locked Only
+                if key in data.__dict__[__locked_attr_list_key]:
+                    __build_data_output += f'{key} {__assignment_operators[1]} {repr(value)}\n'
+                    continue
+                # Normal Assignment
+                __build_data_output += f'{key} {__assignment_operators[0]} {repr(value)}\n'
+
+        # Strip Last \n Char
+        __build_data_output = __build_data_output[:-1]
+
+        # Write New File Mode
+        if write_mode == 'w':
+            __exportfile(filename, __build_data_output)
+        # Append Append File Mode
+        if write_mode == 'a':
+            __appendfile(filename, __build_data_output)
+
+        return None
+
+    # Check if dict
+    if isinstance(data, dict):
+        # Build Data
+        for key,value in data.items():
+            # Multline Assignment from Indentation
+            if indentation_on:
+                if __multiline_check(value):
+                    value = __cleanformat(value, indent_level)
+                    __build_data_output += f'{key} {__assignment_operators[0]} {value}\n'
+                    continue
+            # Single Line Assignment
+            __build_data_output += f'{key} {__assignment_operators[0]} {repr(value)}\n'
+
+        # Strip Last \n Char
+        __build_data_output = __build_data_output[:-1]
+
+        # Write New File Mode
+        if write_mode == 'w':
+            __exportfile(filename, __build_data_output)
+        # Append Append File Mode
+        if write_mode == 'a':
+            __appendfile(filename, __build_data_output)
+
+        return None
+
+    # Report if required types not correct
+
+
+# Functions
+def __multiline_check(data: __Union[list, dict, tuple, set]) -> bool:
+    if isinstance(data, list) \
+    or isinstance(data, dict) \
+    or isinstance(data, tuple) \
+    or isinstance(data, set):
+        return True
+    return False
+

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -40,20 +40,26 @@ def savefile(
             if not key.startswith(__skip_object_key):
                 # Check Operator Type and Build Accordingly
 
-                # Reference and Locked
+                # Reference Name and Locked
                 if (key in data.__dict__[__reference_attr_list_key]) and (key in data.__dict__[__locked_attr_list_key]):
                     __build_data_output += f'{key} {__assignment_operators[3]} {data.__dict__[__reference_attr_list_key][key]}\n'
                     continue
-                # Reference Only
+                # Reference Name Only
                 if key in data.__dict__[__reference_attr_list_key]:
                     __build_data_output += f'{key} {__assignment_operators[2]} {data.__dict__[__reference_attr_list_key][key]}\n'
                     continue
                 # Locked Only
                 if key in data.__dict__[__locked_attr_list_key]:
-                    __build_data_output += f'{key} {__assignment_operators[1]} {repr(value)}\n'
+                    if __multiline_check(value) and indentation_on:
+                        value = __cleanformat(value, indent_level)
+                        __build_data_output += f'{key} {__assignment_operators[1]} {value}\n'
+                    else: __build_data_output += f'{key} {__assignment_operators[1]} {repr(value)}\n'
                     continue
                 # Normal Assignment
-                __build_data_output += f'{key} {__assignment_operators[0]} {repr(value)}\n'
+                if __multiline_check(value) and indentation_on:
+                    value = __cleanformat(value, indent_level)
+                    __build_data_output += f'{key} {__assignment_operators[0]} {value}\n'
+                else: __build_data_output += f'{key} {__assignment_operators[0]} {repr(value)}\n'
 
         # Strip Last \n Char
         __build_data_output = __build_data_output[:-1]

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -3,14 +3,11 @@
 # Imports
 from ast import literal_eval as __literal_eval__
 from typing import Union as __Union
-from ..error import SfcparseError
+from ..error import SaveFile
 from .importfile import SfcparseFileData as __SfcparseFileData
 from .exportfile import exportfile as __exportfile
 from .appendfile import appendfile as __appendfile
 from .cleanformat import cleanformat as __cleanformat
-
-# Exception for Module
-class SaveFile(SfcparseError): __module__ = SfcparseError.set_module_name()
 
 #########################################################################################################
 # Save Data to File

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -26,7 +26,7 @@ def savefile(
     """
     Saves your Attr or Key/Value pair data to a file with the new data.
 
-    Enter filename as str, Pass SfcparseFileData, dict, or custom data type for output to file.
+    Enter filename as str, Pass SfcparseFileData, dict, or custom class data type for output to file.
 
     [Importing Data Back] Functions:
 
@@ -59,7 +59,7 @@ def savefile(
     __err_msg_type_str_write_mode = "Only str is allowed for write_mode"
     __err_msg_type_int_indent_level = "Only int is allowed for indent_level"
     __err_msg_type_bool_indentation_on = "Only bool is allowed for indentation_on"
-    __err_msg_class_instance_error = "Seeing internal built-in names to save. Normally due to a class not being instantiated"
+    __err_msg_class_instance_error = "Seeing internal built-in names to save. Normally due to a class not being instantiated. If intentional, turn off check with 'verify_if_class_instantiated = False'"
 
     if not isinstance(filename, str): raise SaveFile(__err_msg_type_str_filename, f'\nFILE: "{filename}"')
     if not isinstance(write_mode, str): raise SaveFile(__err_msg_type_str_write_mode, f'\nFILE: "{filename}" \nDATA: {write_mode}')

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -20,7 +20,8 @@ def savefile(
     data: __Union['__SfcparseFileData', dict, '__SfcparseDummy.Class'], 
     write_mode: str = 'w',
     indent_level: int = 1,
-    indentation_on: bool = True
+    indentation_on: bool = True,
+    verify_if_class_instantiated = True
     ) -> None:
     """
     Saves your Attr or Key/Value pair data to a file with the new data.
@@ -58,6 +59,7 @@ def savefile(
     __err_msg_type_str_write_mode = "Only str is allowed for write_mode"
     __err_msg_type_int_indent_level = "Only int is allowed for indent_level"
     __err_msg_type_bool_indentation_on = "Only bool is allowed for indentation_on"
+    __err_msg_class_instance_error = "Seeing internal built-in names to save. Normally due to a class not being instantiated"
 
     if not isinstance(filename, str): raise SaveFile(__err_msg_type_str_filename, f'\nFILE: "{filename}"')
     if not isinstance(write_mode, str): raise SaveFile(__err_msg_type_str_write_mode, f'\nFILE: "{filename}" \nDATA: {write_mode}')
@@ -69,6 +71,7 @@ def savefile(
     __build_data_output = ""
     __assignment_operators = ('=', '$=', '==', '$==')
     __skip_object_key = ('_SfcparseFileData', '__sfcparse_file_format_id')
+    __non_instance_names = ['__module__', '__init__']
     __locked_attr_list_key =  '_SfcparseFileData__assignment_locked_attribs'
     __reference_attr_list_key =  '_SfcparseFileData__assignment_reference_attribs'
     __sfcparse_file_format_id_match = "a55acb6b-f87b-4f89-ad11-c9d23eb1307d-7797537e-fb5d-4c69-b84f-2b4da59c04c1"
@@ -151,7 +154,11 @@ def savefile(
     and (not isinstance(data, bytearray)) \
     and (not isinstance(data, memoryview)):
         # Build Data
-        for key,value in data.__dict__.items():            
+        for key,value in data.__dict__.items():
+            # Verify Class is Instantiated
+            if verify_if_class_instantiated:
+                if key in __non_instance_names:
+                    raise SaveFile(__err_msg_class_instance_error, f'\nFILE: "{filename}" \nCLASS: {data} \nATTR_NAME: {key}')
             # Normal Assignment
             if __multiline_check(value) and indentation_on:
                 value = __cleanformat(value, indent_level)

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -2,7 +2,6 @@
 #########################################################################################################
 # Imports
 from ast import literal_eval as __literal_eval__
-from os import path as __path
 from typing import Union as __Union
 from ..error import SfcparseError
 from .importfile import SfcparseFileData as __SfcparseFileData
@@ -15,9 +14,12 @@ class SaveFile(SfcparseError): __module__ = SfcparseError.set_module_name()
 
 #########################################################################################################
 # Save Data to File
+class __SfcparseDummy:
+    class Class: """dummy class for hinting"""
+
 def savefile(
     filename: str, 
-    data: __Union['__SfcparseFileData', dict], 
+    data: __Union['__SfcparseFileData', dict, '__SfcparseDummy.Class'], 
     write_mode: str = 'w',
     indent_level: int = 1,
     indentation_on: bool = True
@@ -33,7 +35,7 @@ def savefile(
     __locked_attr_list_key =  '_SfcparseFileData__assignment_locked_attribs'
     __reference_attr_list_key =  '_SfcparseFileData__assignment_reference_attribs'
 
-    # Check if SfcparseFileData
+    ### SFCPARSE FILE DATA: Check if SfcparseFileData ###
     if isinstance(data, __SfcparseFileData):
         # Build Data
         for key,value in data.__dict__.items():
@@ -62,7 +64,7 @@ def savefile(
                 else: __build_data_output += f'{key} {__assignment_operators[0]} {repr(value)}\n'
 
         # Strip Last \n Char
-        __build_data_output = __build_data_output[:-1]
+        __build_data_output = __build_data_output.rstrip()
 
         # Write New File Mode
         if write_mode == 'w':
@@ -73,7 +75,8 @@ def savefile(
 
         return None
 
-    # Check if dict
+
+    ### DICT: Check if dict ###
     if isinstance(data, dict):
         # Build Data
         for key,value in data.items():
@@ -87,7 +90,7 @@ def savefile(
             __build_data_output += f'{key} {__assignment_operators[0]} {repr(value)}\n'
 
         # Strip Last \n Char
-        __build_data_output = __build_data_output[:-1]
+        __build_data_output = __build_data_output.rstrip()
 
         # Write New File Mode
         if write_mode == 'w':
@@ -98,9 +101,46 @@ def savefile(
 
         return None
 
+
+    ### CLASS: Check if any Class Object with Attributes
+    if (not isinstance(data, str)) \
+    and (not isinstance(data, int)) \
+    and (not isinstance(data, float)) \
+    and (not isinstance(data, bool)) \
+    and (not isinstance(data, list)) \
+    and (not isinstance(data, tuple)) \
+    and (not isinstance(data, set)) \
+    and (not isinstance(data, type(None))) \
+    and (not isinstance(data, bytes)) \
+    and (not isinstance(data, complex)) \
+    and (not isinstance(data, range)) \
+    and (not isinstance(data, frozenset)) \
+    and (not isinstance(data, bytearray)) \
+    and (not isinstance(data, memoryview)):
+        # Build Data
+        for key,value in data.__dict__.items():            
+            # Normal Assignment
+            if __multiline_check(value) and indentation_on:
+                value = __cleanformat(value, indent_level)
+                __build_data_output += f'{key} {__assignment_operators[0]} {value}\n'
+            else: __build_data_output += f'{key} {__assignment_operators[0]} {repr(value)}\n'
+
+        # Strip Last \n Char
+        __build_data_output = __build_data_output.rstrip()
+
+        # Write New File Mode
+        if write_mode == 'w':
+            __exportfile(filename, __build_data_output)
+        # Append Append File Mode
+        if write_mode == 'a':
+            __appendfile(filename, __build_data_output)
+
+        return None
+
+
     # Report if required types not correct
 
-
+#########################################################################################################
 # Functions
 def __multiline_check(data: __Union[list, dict, tuple, set]) -> bool:
     if isinstance(data, list) \

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -37,18 +37,22 @@ def savefile(
     if not isinstance(indent_level, int): raise SaveFile(__err_msg_type_int_indent_level, f'\nFILE: "{filename}" \nDATA: {indent_level}')
     if not isinstance(indentation_on, bool): raise SaveFile(__err_msg_type_bool_indentation_on, f'\nFILE: "{filename}" \nDATA: {indentation_on}')
 
-    
+
     # Save Data to File
     __build_data_output = ""
     __assignment_operators = ('=', '$=', '==', '$==')
-    __skip_object_key = '_SfcparseFileData'
+    __skip_object_key = ('_SfcparseFileData', '__sfcparse_file_format_id')
     __locked_attr_list_key =  '_SfcparseFileData__assignment_locked_attribs'
     __reference_attr_list_key =  '_SfcparseFileData__assignment_reference_attribs'
+    __sfcparse_file_format_id_match = "a55acb6b-f87b-4f89-ad11-c9d23eb1307d-7797537e-fb5d-4c69-b84f-2b4da59c04c1"
+
 
     ### SFCPARSE FILE DATA: Check if SfcparseFileData ###
-    if isinstance(data, __SfcparseFileData):
-        # Build Data
+
+    # Build Out Data
+    if (isinstance(data, __SfcparseFileData)) and (data.__sfcparse_file_format_id__ == __sfcparse_file_format_id_match):
         for key,value in data.__dict__.items():
+            # If Match Prefixes, Skip
             if not key.startswith(__skip_object_key):
                 # Check Operator Type and Build Accordingly
 
@@ -154,6 +158,7 @@ def __multiline_check(data: __Union[list, dict, tuple, set]) -> bool:
     or isinstance(data, set):
         return True
     return False
+
 
 # Write File Data
 def __write_file_data(filename: str, data: __Any, write_mode: str) -> None:

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -177,5 +177,5 @@ def __write_file_data(filename: str, data: __Any, write_mode: str) -> None:
         # Raise Exception if No Match
         if not write_mode in __write_mode_allowed_list:
             raise SaveFile(__err_msg_write_mode, f'\nFILE: "{filename}" \nDATA: {write_mode}')
-    except ExportFile as __err: raise SaveFile(__err, '')
-    except AppendFile as __err: raise SaveFile(__err, '')
+    except ExportFile as __err_msg: raise SaveFile(__err_msg, '')
+    except AppendFile as __err_msg: raise SaveFile(__err_msg, '')

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -55,6 +55,7 @@ def savefile(
     """
     # Error Checks
     __err_msg_general_error = "Error has occurred and cannot proceed"
+    __err_msg_no_attrs_found = "Cannot save file. No attributes found in the object passed"
     __err_msg_type_str_filename = "Only str is allowed for filename"
     __err_msg_type_str_write_mode = "Only str is allowed for write_mode"
     __err_msg_type_int_indent_level = "Only int is allowed for indent_level"
@@ -173,6 +174,9 @@ def savefile(
 
         return None
 
+    # Report if no __dict__ Attribute
+    if not hasattr(data, '__dict__'):
+        raise SaveFile(__err_msg_no_attrs_found, f'\nFILE: "{filename}" \nDATA: {data}')
 
     # Report if Error not Definable
     raise SaveFile(__err_msg_general_error, f'\nDATA: {data}')

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -23,7 +23,34 @@ def savefile(
     indentation_on: bool = True
     ) -> None:
     """
-    savefile
+    Saves your Attr or Key/Value pair data to a file with the new data.
+
+    Enter filename as str, Pass SfcparseFileData, dict, or custom data type for output to file.
+
+    [Importing Data Back] Functions:
+
+    importfile: Import data back returning a class of attributes with Sfcparse features
+
+    importattrs: Import attributes back into a custom class. This is done in-place
+
+    [Options]
+
+    write_mode:
+
+    'w' = write new file with new data (Default)
+
+    'a' = append new data to existing file
+
+    indent_level: set indent level for types list, dict, tuple, set (Default 1)
+
+    indentation_on: set to False to turn OFF indentation on types list, dict, tuple, set (Default ON)
+
+    [Example Use]
+    Normal: savefile('path/of/filename', 'data')
+
+    Append to File: savefile('path/of/filename', 'data', write_mode='a')
+
+    Indent OFF: savefile('path/of/filename', 'data', indentation_on=False)
     """
     # Error Checks
     __err_msg_general_error = "Error has occurred and cannot proceed"

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -1,0 +1,18 @@
+# savefile
+#########################################################################################################
+# Imports
+from ast import literal_eval as __literal_eval__
+from os import path as __path
+from typing import Any as _Any
+from ..error import SfcparseError
+
+# Exception for Module
+class SaveFile(SfcparseError): __module__ = SfcparseError.set_module_name()
+
+#########################################################################################################
+# Save Data to File
+def savefile():
+    """
+    savefile
+    """
+    pass

--- a/src/sfcparse/__native/savefile.py
+++ b/src/sfcparse/__native/savefile.py
@@ -3,15 +3,16 @@
 # Imports
 from ast import literal_eval as __literal_eval__
 from os import path as __path
-from typing import Any as _Any
+from typing import Union as __Union
 from ..error import SfcparseError
+from .importfile import SfcparseFileData as __SfcparseFileData
 
 # Exception for Module
 class SaveFile(SfcparseError): __module__ = SfcparseError.set_module_name()
 
 #########################################################################################################
 # Save Data to File
-def savefile():
+def savefile(filename: str, data: __Union['__SfcparseFileData', dict]) -> None:
     """
     savefile
     """

--- a/src/sfcparse/__xml/xmlbuildmanual.py
+++ b/src/sfcparse/__xml/xmlbuildmanual.py
@@ -7,7 +7,7 @@ import xml.etree.ElementTree as __xml_etree
 # Build manual xml data
 def xmlbuildmanual() -> __xml_etree:
     """
-    Returns a empty xml ElementTree obj to build/work with xml data
+    Returns an empty xml ElementTree obj to build/work with xml data
     
     Assign the output to var
 

--- a/src/sfcparse/__xml/xmlexportfile.py
+++ b/src/sfcparse/__xml/xmlexportfile.py
@@ -4,10 +4,7 @@
 from ..__native.exportfile import exportfile
 from .xmlexportstr import xmlexportstr
 import xml.etree.ElementTree as __xml_etree
-from ..error import SfcparseError
-
-# Exception for Module
-class XmlExportFile(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import XmlExportFile
 
 #########################################################################################################
 # Export xml file

--- a/src/sfcparse/__xml/xmlexportstr.py
+++ b/src/sfcparse/__xml/xmlexportstr.py
@@ -2,10 +2,7 @@
 #########################################################################################################
 # Imports
 import xml.etree.ElementTree as __xml_etree
-from ..error import SfcparseError
-
-# Exception for Module
-class XmlExportStr(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import XmlExportStr
 
 #########################################################################################################
 # Export xml str

--- a/src/sfcparse/__xml/xmlimportfile.py
+++ b/src/sfcparse/__xml/xmlimportfile.py
@@ -2,10 +2,7 @@
 #########################################################################################################
 # Imports
 import xml.etree.ElementTree as __xml_etree
-from ..error import SfcparseError
-
-# Exception for Module
-class XmlImportFile(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import XmlImportFile
 
 #########################################################################################################
 # Import xml file

--- a/src/sfcparse/__xml/xmlimportstr.py
+++ b/src/sfcparse/__xml/xmlimportstr.py
@@ -2,10 +2,7 @@
 #########################################################################################################
 # Imports
 import xml.etree.ElementTree as __xml_etree
-from ..error import SfcparseError
-
-# Exception for Module
-class XmlImportStr(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import XmlImportStr
 
 #########################################################################################################
 # Import xml str

--- a/src/sfcparse/__yaml/yamlexportfile.py
+++ b/src/sfcparse/__yaml/yamlexportfile.py
@@ -3,10 +3,7 @@
 # Imports
 from typing import Any as __Any
 import yaml as __yaml
-from ..error import SfcparseError
-
-# Exception for Module
-class YamlExportFile(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import YamlExportFile
 
 #########################################################################################################
 # Export yaml file

--- a/src/sfcparse/__yaml/yamlexportstr.py
+++ b/src/sfcparse/__yaml/yamlexportstr.py
@@ -3,10 +3,7 @@
 # Imports
 from typing import Any as __Any
 import yaml as __yaml
-from ..error import SfcparseError
-
-# Exception for Module
-class YamlExportStr(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import YamlExportStr
 
 #########################################################################################################
 # Export yaml str

--- a/src/sfcparse/__yaml/yamlimportfile.py
+++ b/src/sfcparse/__yaml/yamlimportfile.py
@@ -3,10 +3,7 @@
 # Imports
 from typing import Any as __Any
 import yaml as __yaml
-from ..error import SfcparseError
-
-# Exception for Module
-class YamlImportFile(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import YamlImportFile
 
 #########################################################################################################
 # Import yaml file

--- a/src/sfcparse/__yaml/yamlimportstr.py
+++ b/src/sfcparse/__yaml/yamlimportstr.py
@@ -3,10 +3,7 @@
 # Imports
 from typing import Any as __Any
 import yaml as __yaml
-from ..error import SfcparseError
-
-# Exception for Module
-class YamlImportStr(SfcparseError): __module__ = SfcparseError.set_module_name()
+from ..error import YamlImportStr
 
 #########################################################################################################
 # Import yaml str

--- a/src/sfcparse/error.py
+++ b/src/sfcparse/error.py
@@ -1,16 +1,52 @@
-# error - Contains base exception
+# error - Contains base exceptions
+
+# Base Exception
 class SfcparseError(Exception):
     """
     sfcparse base exception
     """
-    __PARENT_EXCEPTION_NAME = 'sfcparse'
-
-    def __init__(self, msg: str, item: str='') -> None:
+    def __init__(self, msg: str, item: str = '') -> None:
         self.msg = str(msg)
         self.item = str(item)
 
     def __str__(self) -> str:
         return f'[Error] {self.msg} {self.item}'
-    
-    def set_module_name(module_name: str=__PARENT_EXCEPTION_NAME):
-        return module_name
+
+
+# Module Exceptions
+
+# Native
+class ImportFile(SfcparseError): __module__ = 'sfcparse.error'
+class ImportFileRaw(SfcparseError): __module__ = 'sfcparse.error'
+class ImportAttrs(SfcparseError): __module__ = 'sfcparse.error'
+class AppendFile(SfcparseError): __module__ = 'sfcparse.error'
+class ExportFile(SfcparseError): __module__ = 'sfcparse.error'
+class CleanFormat(SfcparseError): __module__ = 'sfcparse.error'
+class SaveFile(SfcparseError): __module__ = 'sfcparse.error'
+
+# Hash
+class CompareFileHash(SfcparseError): __module__ = 'sfcparse.error'
+class CreateFileHash(SfcparseError): __module__ = 'sfcparse.error'
+
+# JSON
+class JsonImportFile(SfcparseError): __module__ = 'sfcparse.error'
+class JsonImportStr(SfcparseError): __module__ = 'sfcparse.error'
+class JsonExportFile(SfcparseError): __module__ = 'sfcparse.error'
+class JsonExportStr(SfcparseError): __module__ = 'sfcparse.error'
+
+# YAML
+class YamlImportFile(SfcparseError): __module__ = 'sfcparse.error'
+class YamlImportStr(SfcparseError): __module__ = 'sfcparse.error'
+class YamlExportFile(SfcparseError): __module__ = 'sfcparse.error'
+class YamlExportStr(SfcparseError): __module__ = 'sfcparse.error'
+
+# INI
+class IniImportFile(SfcparseError): __module__ = 'sfcparse.error'
+class IniExportFile(SfcparseError): __module__ = 'sfcparse.error'
+class IniBuildAuto(SfcparseError): __module__ = 'sfcparse.error'
+
+# XML
+class XmlImportFile(SfcparseError): __module__ = 'sfcparse.error'
+class XmlImportStr(SfcparseError): __module__ = 'sfcparse.error'
+class XmlExportFile(SfcparseError): __module__ = 'sfcparse.error'
+class XmlExportStr(SfcparseError): __module__ = 'sfcparse.error'

--- a/src/sfcparse/error.py
+++ b/src/sfcparse/error.py
@@ -15,6 +15,9 @@ class SfcparseError(Exception):
 
 # Module Exceptions
 
+# General Error
+class GeneralError(SfcparseError): __module__ = 'sfcparse.error'
+
 # Native
 class ImportFile(SfcparseError): __module__ = 'sfcparse.error'
 class ImportFileRaw(SfcparseError): __module__ = 'sfcparse.error'

--- a/tests/native/test_builddata.py
+++ b/tests/native/test_builddata.py
@@ -1,0 +1,150 @@
+# builddata - Tests
+from src import sfcparse
+from os import path, remove
+import time
+import unittest
+
+test_file_path = './tests/test_files/native/builddata_files/'
+file_delay_timer = 0.5
+
+################################################################
+# TESTS
+
+class TestBuildData(unittest.TestCase):
+
+    # 1. Build Data - Testing raw data build storing to file and importing
+    def test1_build_data_sfcparse(self):
+        filename = '1_build_data_sfcparse.data'
+        filepath = test_file_path + filename
+
+        # Build Data
+        build_data = sfcparse.builddata()
+        build_data.data_str = "data"
+        build_data.data_int = 1
+        build_data.data_float = 1.0
+        build_data.data_bool = True
+        build_data.data_list = [1,2,3]
+        build_data.data_dict = {'k1':1, 'k2':2, 'k3':3}
+        build_data.data_tuple = (1,2,3)
+        build_data.data_set = {1,2,3}
+        build_data.data_none = None
+        build_data.data_bytes = b'data'
+
+        # Store Data
+        sfcparse.savefile(filepath, build_data)
+
+        # Test Importing Data
+        file_import = sfcparse.importfile(filepath)
+
+        # Test Imported Data
+        self.assertEqual(file_import.data_str, "data")
+        self.assertEqual(file_import.data_int, 1)
+        self.assertEqual(file_import.data_float, 1.0)
+        self.assertEqual(file_import.data_bool, True)
+        self.assertEqual(file_import.data_list, [1,2,3])
+        self.assertEqual(file_import.data_dict, {'k1':1, 'k2':2, 'k3':3})
+        self.assertEqual(file_import.data_tuple, (1,2,3))
+        self.assertEqual(file_import.data_set, {1,2,3})
+        self.assertEqual(file_import.data_none, None)
+        self.assertEqual(file_import.data_bytes, b'data')
+
+        # Remove Test File
+        time.sleep(file_delay_timer)
+        try: remove(filepath)
+        except: pass
+
+    # 2. Build Data - Testing raw data build and method concepts, storing to file and importing method retention
+    def test2_build_data_methods_sfcparse(self):
+        filename = '2_build_data_methods_sfcparse.data'
+        filepath = test_file_path + filename
+
+        # Build Data
+        build_data = sfcparse.builddata()
+        build_data.data_str = "data"
+        build_data.data_int = 1
+        build_data.data_float = 1.0
+        build_data.data_bool = True
+        build_data.data_dict = {'k1':1, 'k2':2, 'k3':3}
+        build_data.data_list = [1,2,3]
+        build_data.data_tuple = (1,2,3)
+        build_data.data_set = {1,2,3}
+        build_data.data_none = None
+        build_data.data_bytes = b'data'
+
+        # LOCKING
+        build_data.lock_attr('data_none')
+
+        # Test Locked Attribute
+        with self.assertRaises(Exception): build_data.data_none = True
+        self.assertEqual(build_data.data_none, None)
+
+
+        # UNLOCKING
+        build_data.unlock_attr('data_none')
+
+        # Test Unlocking Attribute
+        build_data.data_none = True
+        self.assertEqual(build_data.data_none, True)
+        
+        # Test Unlocking Exception when already Unlocked
+        with self.assertRaises(Exception): build_data.unlock_attr('data_none')
+    
+        
+        # REFERENCE
+        build_data.reference_attr('data_none', 'data_list')
+
+        # Test Attribute Reference
+        self.assertEqual(build_data.data_none, [1,2,3])
+        # Reset back to Normal
+        build_data.data_none = None
+
+        # REFERENCE LOCK
+        build_data.reference_attr('data_none', 'data_list')
+        build_data.lock_attr('data_none')
+
+        # Test Attribute Reference Value and Lock
+        with self.assertRaises(Exception): build_data.data_none = True
+        self.assertEqual(build_data.data_none, [1,2,3])
+        # Reset back to Normal
+        build_data.unlock_attr('data_none')
+        build_data.data_none = None
+
+
+        # Save and Import Mixed Setups
+        # Setup Different Locked and Reference Locked Values, Unlock a value from file import as well
+        
+        # Tuple
+        build_data.lock_attr('data_tuple')
+        # Str
+        build_data.lock_attr('data_str')
+        # List
+        build_data.reference_attr('data_list', 'data_dict')
+        # Set
+        build_data.reference_attr('data_set', 'data_bool')
+        build_data.lock_attr('data_set')
+        sfcparse.savefile(filepath, build_data)
+
+        # Test Importing Data
+        file_import = sfcparse.importfile(filepath)
+
+        # Test Imported Data
+        
+        # Tuple
+        with self.assertRaises(Exception): file_import.data_tuple = True
+        self.assertEqual(file_import.data_tuple, (1,2,3))
+
+        # Str
+        with self.assertRaises(Exception): file_import.data_str = True
+        self.assertEqual(file_import.data_str, "data")
+
+        # List
+        self.assertEqual(file_import.data_list, {'k1':1, 'k2':2, 'k3':3})
+
+        # Set
+        with self.assertRaises(Exception): file_import.data_set = False
+        self.assertEqual(file_import.data_set, True)
+
+        # Remove Test File
+        time.sleep(file_delay_timer)
+        try: remove(filepath)
+        except: pass

--- a/tests/native/test_builddata.py
+++ b/tests/native/test_builddata.py
@@ -55,7 +55,7 @@ class TestBuildData(unittest.TestCase):
 
     # 2. Build Data - Testing raw data build and method concepts, storing to file and importing method retention
     def test2_build_data_methods_sfcparse(self):
-        filename = '2_build_data_methods.data'
+        filename = '2_build_data_methods_sfcparse.data'
         filepath = test_file_path + filename
 
         # Build Data

--- a/tests/native/test_builddata.py
+++ b/tests/native/test_builddata.py
@@ -55,7 +55,7 @@ class TestBuildData(unittest.TestCase):
 
     # 2. Build Data - Testing raw data build and method concepts, storing to file and importing method retention
     def test2_build_data_methods_sfcparse(self):
-        filename = '2_build_data_methods_sfcparse.data'
+        filename = '2_build_data_methods.data'
         filepath = test_file_path + filename
 
         # Build Data

--- a/tests/native/test_importattrs.py
+++ b/tests/native/test_importattrs.py
@@ -1,0 +1,58 @@
+# importattrs - Tests
+from src import sfcparse
+import unittest
+
+test_file_path = './tests/test_files/native/importattrs_files/'
+
+################################################################
+# TESTS
+
+class TestImportAttrs(unittest.TestCase):
+
+    # 1. Importing Attrs - Testing importing attributes from file to Custom Class / New Class
+    def test1_import_attrs_class(self):
+        filename = '1_import_attrs_class.data'
+        filepath = test_file_path + filename
+
+        # Test Data Custom Class
+        class TemplateData:
+            def __init__(self) -> None:
+                self.data_list = [1,2,3]
+                self.data_bool = True
+                self.data_int = 1
+        class_data = TemplateData()
+
+        class NewObjData: pass
+
+        # Original Class
+        # Update Values to Simulate Restore from Original to Prove Import
+        class_data.data_bool = False
+        class_data.data_list.append(4)
+        class_data.data_int = 2
+
+        # Test Importing Attrs Back
+        sfcparse.importattrs(filepath, class_data)
+
+        # Test Imported Data of their Original Values Stored
+        self.assertEqual(class_data.data_list, [1,2,3])
+        self.assertEqual(class_data.data_bool, True)
+        self.assertEqual(class_data.data_int, 1)
+
+        # Instance Object
+        # Test Importing Attrs to New Object
+        new_class_data = NewObjData()
+        sfcparse.importattrs(filepath, new_class_data)
+
+        # Test Imported Data of their Original Values Stored from Instance
+        self.assertEqual(new_class_data.data_list, [1,2,3])
+        self.assertEqual(new_class_data.data_bool, True)
+        self.assertEqual(new_class_data.data_int, 1)
+
+        # Root Class
+        # Test Importing Attrs to Root Class Object
+        sfcparse.importattrs(filepath, NewObjData)
+
+        # Test Imported Data of their Original Values Stored from Root Class
+        self.assertEqual(NewObjData.data_list, [1,2,3])
+        self.assertEqual(NewObjData.data_bool, True)
+        self.assertEqual(NewObjData.data_int, 1)

--- a/tests/native/test_savefile.py
+++ b/tests/native/test_savefile.py
@@ -1,0 +1,196 @@
+# savefile - Tests
+from src import sfcparse
+from os import path, remove
+import time
+import unittest
+
+test_file_path = './tests/test_files/native/savefile_files/'
+file_delay_timer = 0.5
+
+################################################################
+# TESTS
+
+class TestSaveFile(unittest.TestCase):
+
+    # 1. Save File - Testing a basic save file
+    def test1_basic_save_file(self):
+        filename = '1_basic_save_file.data'
+        template_file = 'template_single_line.data'
+        filepath = test_file_path + filename
+        template_file = test_file_path + template_file
+
+        # Import Template Data
+        file_import = sfcparse.importfile(template_file)
+
+        # Remove Any Existing Test File
+        try: remove(filepath)
+        except: pass
+        time.sleep(file_delay_timer)
+
+        # Test Not Exist, Create, Test Exist
+        self.assertEqual(path.exists(filepath), False)
+        sfcparse.savefile(filepath, file_import)
+        self.assertEqual(path.exists(filepath), True)
+
+        # Remove Test File
+        time.sleep(file_delay_timer)
+        try: remove(filepath)
+        except: pass
+
+    # 2. Save File: sfcparse - Testing a save file and importing values to test formatting stored
+    def test2_save_file_formatting_sfcparse(self):
+        filename = '2_save_file_formatting_sfcparse.data'
+        template_file = 'template_single_line.data'
+        filepath = test_file_path + filename
+        template_file = test_file_path + template_file
+
+        # Import Template Data
+        file_import_template = sfcparse.importfile(template_file)
+
+        # Store Data
+        sfcparse.savefile(filepath, file_import_template)
+
+        # Test Importing Data
+        file_import = sfcparse.importfile(filepath)
+
+        # Test Imported Data
+        self.assertEqual(file_import.data_str, "data")
+        self.assertEqual(file_import.data_int, 1)
+        self.assertEqual(file_import.data_float, 1.0)
+        self.assertEqual(file_import.data_bool, True)
+        self.assertEqual(file_import.data_list, [1,2,3])
+        self.assertEqual(file_import.data_dict, {'k1':1, 'k2':2, 'k3':3})
+        self.assertEqual(file_import.data_tuple, [1,2,3])
+        self.assertEqual(file_import.data_set, [1,2,3])
+        self.assertEqual(file_import.data_none, {'k1':1, 'k2':2, 'k3':3})
+        self.assertEqual(file_import.data_bytes, b'data')
+
+        # Remove Test File
+        time.sleep(file_delay_timer)
+        try: remove(filepath)
+        except: pass
+    
+    # 3. Save File: dict - Testing a save file and importing values to test formatting stored
+    def test3_save_file_formatting_dict(self):
+        filename = '3_save_file_formatting_dict.data'
+        template_file = 'template_single_line.data'
+        filepath = test_file_path + filename
+        template_file = test_file_path + template_file
+
+        # Import Template Data
+        file_import_template = sfcparse.importfile(template_file)
+
+        # Store Data
+        sfcparse.savefile(filepath, file_import_template.data_dict)
+
+        # Test Importing Data
+        file_import = sfcparse.importfile(filepath)
+
+        # Test Imported Data
+        self.assertEqual(file_import.k1, 1)
+        self.assertEqual(file_import.k2, 2)
+        self.assertEqual(file_import.k3, 3)
+
+        # Remove Test File
+        time.sleep(file_delay_timer)
+        try: remove(filepath)
+        except: pass
+
+    # 4. Save File: class - Testing a save file and importing values to test formatting stored
+    def test4_save_file_formatting_class(self):
+        filename = '4_save_file_formatting_class.data'
+        filepath = test_file_path + filename
+
+        # Test Data Custom Class
+        class TemplateData:
+            def __init__(self) -> None:
+                self.data_list = [1,2,3]
+                self.data_bool = True
+                self.data_int = 1
+        class_data = TemplateData()
+
+        # Store Data
+        sfcparse.savefile(filepath, class_data)
+
+        # Test Importing Data
+        file_import = sfcparse.importfile(filepath)
+
+        # Test Imported Data
+        self.assertEqual(file_import.data_list, [1,2,3])
+        self.assertEqual(file_import.data_bool, True)
+        self.assertEqual(file_import.data_int, 1)
+
+        # Remove Test File
+        time.sleep(file_delay_timer)
+        try: remove(filepath)
+        except: pass
+
+    # 5. Save File: class - Testing Indentation
+    def test5_save_file_indentation_class(self):
+        filename = '5_save_file_indentation_class.data'
+        filepath = test_file_path + filename
+
+        # Test Data Custom Class
+        class TemplateData:
+            def __init__(self) -> None:
+                self.data_list = [1,2,3]
+                self.data_bool = True
+                self.data_int = 1
+        class_data = TemplateData()
+
+        # INDENTATION
+        # Store Data
+        sfcparse.savefile(filepath, class_data, indentation_on=False)
+
+        # Import Data and Set Line Count
+        file_import = sfcparse.importfileraw(filepath)
+        file_import_lines = len(file_import.splitlines())
+
+        # Test Data
+        expected_file_lines = 3
+        self.assertEqual(file_import_lines, expected_file_lines)
+
+        # INDENT LEVEL
+        # Store Data
+        sfcparse.savefile(filepath, class_data, indent_level=5)
+
+        # Import Data
+        file_import = sfcparse.importfile(filepath)
+
+        # Test Data
+        self.assertEqual(file_import.data_list, [1,2,3])
+
+        # Remove Test File
+        time.sleep(file_delay_timer)
+        try: remove(filepath)
+        except: pass
+
+    # 6. Save File: class - Testing Appending
+    def test6_save_file_append_class(self):
+        filename = '6_save_file_append_class.data'
+        filepath = test_file_path + filename
+
+        # Test Data Custom Class
+        class TemplateData:
+            def __init__(self) -> None:
+                self.data_list = [1,2,3]
+                self.data_bool = True
+                self.data_int = 1
+        class_data = TemplateData()
+
+        # Store Data, then Append to it
+        sfcparse.savefile(filepath, class_data, indentation_on=False)
+        sfcparse.savefile(filepath, class_data, write_mode='a', indentation_on=False)
+
+        # Import Data and Set Line Count
+        file_import = sfcparse.importfileraw(filepath)
+        file_import_lines = len(file_import.splitlines())
+
+        # Test Data
+        expected_file_lines = 6
+        self.assertEqual(file_import_lines, expected_file_lines)
+
+        # Remove Test File
+        time.sleep(file_delay_timer)
+        try: remove(filepath)
+        except: pass

--- a/tests/test_files/native/importattrs_files/1_import_attrs_class.data
+++ b/tests/test_files/native/importattrs_files/1_import_attrs_class.data
@@ -1,0 +1,7 @@
+data_list = [
+	1,
+	2,
+	3,
+]
+data_bool = True
+data_int = 1

--- a/tests/test_files/native/savefile_files/template_single_line.data
+++ b/tests/test_files/native/savefile_files/template_single_line.data
@@ -1,0 +1,10 @@
+data_str = "data"
+data_int $= 1
+data_float = 1.0
+data_bool = True
+data_list = [1,2,3]
+data_dict $= {'k1':1, 'k2':2, 'k3':3}
+data_tuple == data_list
+data_set == data_tuple
+data_none $== data_dict
+data_bytes = b'data'


### PR DESCRIPTION
Beaking Change: 
- Changed importfile function to return SfcparseFileData obj name instead of FileData
- This was the reason for 2.0.0 increment following SemVer

New Features:
savefile:
- Save SfcparseFileData format with retention of features and structure
- Save dict data to be converted to SfcparseFileData format (does not retain SfcparseFileData features and structure)
- Save any Class Object with Attributes to SfcparseFileData format (does not retain SfcparseFileData features and structure)

importattrs:
- Import file stored as python/sfcparse format and inject imported attrs into Class Obj

builddata:
- Ability to build python data with sfcparse features that can be stored to file with feature retention

Updates:
importfile:
- Added new methods to new SfcparseFileData obj for more control and interaction over features
- Method Added: lock_attr
- Method Added: unlock_attr
- Method Added: reference_attr

Changes
- New Exception Structure to allow ability to except sfcparse exception names properly and easily

Tests:
- Added new tests to test structure for new features

Misc:
- Updated comments and docstrings